### PR TITLE
Enable mouse/touch fallback when camera fails

### DIFF
--- a/app.js
+++ b/app.js
@@ -194,17 +194,31 @@ hands.onResults(({multiHandLandmarks:[lm]})=>{
 });
 
 /* ---------- Video / cámara ---------- */
+function startWithoutCamera(msg){
+  msgEl.textContent = msg;
+  overlay.classList.remove('hidden');
+  setTimeout(() => overlay.classList.add('hidden'), 2000);
+}
+
 function startCamera(){
-  navigator.mediaDevices.getUserMedia({video:{width:640,height:480}})
-    .then(str=>{video.srcObject=str;video.play();})
-    .catch(err=>{
-      msgEl.textContent = 'Error al acceder a la c\u00e1mara: '+err.message;
-      overlay.classList.remove('hidden');
+  const media = navigator.mediaDevices;
+  if(!media || !media.getUserMedia){
+    startWithoutCamera('C\u00e1mara no disponible. Usa mouse o t\u00e1ctil.');
+    return;
+  }
+
+  media.getUserMedia({video:{width:640,height:480}})
+    .then(str => {
+      video.srcObject = str;
+      video.play();
+      overlay.classList.add('hidden');
+    })
+    .catch(() => {
+      startWithoutCamera('No se detect\u00f3 la c\u00e1mara. Usa mouse o t\u00e1ctil.');
     });
 }
 
 startBtn.onclick=()=>{
-  overlay.classList.add('hidden');
   startCamera();
 };
 

--- a/index.html
+++ b/index.html
@@ -83,8 +83,8 @@
   <video id="camera"></video>
   <!-- ---------- Ventana de inicio ---------- -->
   <div id="overlay">
-    <p>Se requiere conceder permiso de cámara para utilizar el demo.</p>
-    <p>Coloca la mano frente a la cámara y une índice y pulgar para interactuar.</p>
+    <p>Permite la cámara para usar gestos de mano.</p>
+    <p>Si no está disponible, podrás usar el mouse o la pantalla táctil.</p>
     <p id="overlay-msg"></p>
     <button id="start-btn">Comenzar</button>
   </div>


### PR DESCRIPTION
## Summary
- inform users they can still use the demo without a camera
- show a brief message and hide the overlay automatically when the camera isn't available

## Testing
- `node --check app.js`
- `node server.js` & `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_686bc45fcba483318887c91460043a61