### PR TITLE
Fix import paths for three.js addons

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /* ---------- Imports ---------- */
 import * as THREE from 'three';
-import {CSS3DRenderer, CSS3DObject} from 'three/addons/renderers/CSS3DRenderer.js';
-import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
+import {CSS3DRenderer, CSS3DObject} from 'three/addons/CSS3DRenderer.js';
+import {OrbitControls} from 'three/addons/OrbitControls.js';
 
 /* ---------- Constantes ---------- */
 const container = document.getElementById('container');


### PR DESCRIPTION
## Summary
- fix incorrect paths to OrbitControls.js and CSS3DRenderer.js

## Testing
- `node --check app.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_686bdee742908331affd33c51eb65813