### PR TITLE
Focus windows on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
       transition:opacity .3s ease,transform .3s ease;
     }
     .window.active{opacity:1;transform:scale(1)}
+    .window.focused{box-shadow:0 0 0 2px var(--accent),var(--shadow)}
     .titlebar{
       background:var(--accent);color:#fff;padding:6px 10px;
       display:flex;justify-content:space-between;align-items:center;

--- a/src/win.js
+++ b/src/win.js
@@ -3,6 +3,8 @@ import { CSS3DObject } from 'three/addons/CSS3DRenderer.js';
 import { createApp } from './apps.js';
 
 let sceneCSS;
+let focusedWin = null;
+let zCounter = 1;
 
 export function initWindowSystem(scene) {
   sceneCSS = scene;
@@ -13,6 +15,9 @@ export class Win {
     this.root = document.createElement('div');
     this.root.className = 'window';
     this.root.id = `win-${id}`;
+
+    this.root.addEventListener('mousedown', () => this.focus());
+    this.root.addEventListener('touchstart', () => this.focus());
 
     /* Título */
     const title = document.createElement('div');
@@ -25,6 +30,7 @@ export class Win {
     close.onclick = () => {
       if (this.interval) clearInterval(this.interval);
       this.root.classList.remove('active');
+      if (focusedWin === this) focusedWin = null;
       this.root.addEventListener('transitionend', () => sceneCSS.remove(this.obj), { once: true });
     };
     title.appendChild(close);
@@ -46,11 +52,23 @@ export class Win {
     this.obj = new CSS3DObject(this.root);
     this.obj.position.set(0, 0, 120);
     sceneCSS.add(this.obj);
+    this.focus();
     requestAnimationFrame(() => this.root.classList.add('active'));
 
     /* Drag */
     this.#enableDrag(title);
     this.#enableResize(resizer);
+  }
+
+  focus() {
+    if (focusedWin && focusedWin !== this) {
+      focusedWin.root.classList.remove('focused');
+    }
+    focusedWin = this;
+    this.root.classList.add('focused');
+    this.root.style.zIndex = (++zCounter).toString();
+    sceneCSS.remove(this.obj);
+    sceneCSS.add(this.obj);
   }
 
   #enableDrag(bar) {


### PR DESCRIPTION
## Summary
- manage focused window state
- prioritize focused window via z-index and reorder
- style focused windows with outline

## Testing
- `node --check src/win.js`
- `node --check src/main.js`

------
https://chatgpt.com/codex/tasks/task_e_686c29b16e7483319163d64452fef903