### PR TITLE
Implement in-memory file system for terminal

### DIFF
--- a/src/apps.js
+++ b/src/apps.js
@@ -1,4 +1,5 @@
 import { runPluginApp } from './pluginApi.js';
+import fs from './fs.js';
 
 export function createApp(id, cont, win) {
   if (runPluginApp(id, cont, win)) return;
@@ -13,21 +14,41 @@ export function createApp(id, cont, win) {
 
       function runCmd(cmd) {
         const [c, ...args] = cmd.split(' ');
-        switch (c) {
-          case 'help':
-            pre.textContent += '\nComandos: help, echo, date, clear';
-            break;
-          case 'echo':
-            pre.textContent += '\n' + args.join(' ');
-            break;
-          case 'date':
-            pre.textContent += '\n' + new Date().toString();
-            break;
-          case 'clear':
-            pre.textContent = 'Terminal >';
-            break;
-          default:
-            if (c) pre.textContent += `\nComando desconocido: ${c}`;
+        try {
+          switch (c) {
+            case 'help':
+              pre.textContent += '\nComandos: help, echo, date, clear, ls, cat, write, mkdir';
+              break;
+            case 'echo':
+              pre.textContent += '\n' + args.join(' ');
+              break;
+            case 'date':
+              pre.textContent += '\n' + new Date().toString();
+              break;
+            case 'clear':
+              pre.textContent = 'Terminal >';
+              break;
+            case 'ls': {
+              const list = fs.ls(args[0] || '/');
+              pre.textContent += '\n' + list.join(' ');
+              break;
+            }
+            case 'cat':
+              pre.textContent += '\n' + fs.cat(args[0]);
+              break;
+            case 'write': {
+              const [file, ...text] = args;
+              fs.write(file, text.join(' '));
+              break;
+            }
+            case 'mkdir':
+              fs.mkdir(args[0]);
+              break;
+            default:
+              if (c) pre.textContent += `\nComando desconocido: ${c}`;
+          }
+        } catch (e) {
+          pre.textContent += '\n' + e.message;
         }
       }
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,0 +1,62 @@
+const FS_KEY = 'memfs';
+let root;
+try {
+  root = JSON.parse(localStorage.getItem(FS_KEY)) || { type: 'dir', children: {} };
+} catch {
+  root = { type: 'dir', children: {} };
+}
+
+function save() {
+  localStorage.setItem(FS_KEY, JSON.stringify(root));
+}
+
+function getNode(path) {
+  if (!path || path === '/') return root;
+  const parts = path.split('/').filter(Boolean);
+  let node = root;
+  for (const p of parts) {
+    if (!node.children || !node.children[p]) return null;
+    node = node.children[p];
+  }
+  return node;
+}
+
+function getParent(path) {
+  const parts = path.split('/').filter(Boolean);
+  const name = parts.pop();
+  const parent = parts.length ? getNode('/' + parts.join('/')) : root;
+  return { parent, name };
+}
+
+function ls(path = '/') {
+  const node = getNode(path);
+  if (!node || node.type !== 'dir') throw new Error('No existe el directorio: ' + path);
+  return Object.keys(node.children);
+}
+
+function cat(path) {
+  const node = getNode(path);
+  if (!node || node.type !== 'file') throw new Error('No existe el archivo: ' + path);
+  return node.content;
+}
+
+function write(path, content = '') {
+  const { parent, name } = getParent(path);
+  if (!parent || parent.type !== 'dir') throw new Error('No existe el directorio: ' + path);
+  parent.children[name] = { type: 'file', content };
+  save();
+}
+
+function mkdir(path) {
+  const parts = path.split('/').filter(Boolean);
+  let node = root;
+  for (const p of parts) {
+    if (!node.children[p]) node.children[p] = { type: 'dir', children: {} };
+    else if (node.children[p].type !== 'dir') throw new Error(p + ' ya existe y no es un directorio');
+    node = node.children[p];
+  }
+  save();
+}
+
+export default { ls, cat, write, mkdir };
+window.fs = { ls, cat, write, mkdir };


### PR DESCRIPTION
## Summary
- add a persistent in-memory filesystem
- expose fs commands `ls`, `cat`, `write`, `mkdir`
- extend terminal to handle the new commands and show errors

## Testing
- `node -p "1+1"`

------
https://chatgpt.com/codex/tasks/task_e_686c334b34d8833194dbbd83a9b42f31