### PR TITLE
Add start menu search

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,9 @@
 
   <div id="taskbar">
     <button id="start-button">Inicio</button>
-    <div id="start-menu"></div>
+    <div id="start-menu">
+      <input type="text" id="start-search" placeholder="Buscar...">
+    </div>
     <div id="taskbar-windows"></div>
   </div>
   <div id="toast-container"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const overlayStartBtn  = document.getElementById('start-btn');
 const cameraSelect = document.getElementById('camera-select');
 const startButton = document.getElementById('start-button');
 const startMenu   = document.getElementById('start-menu');
+const startSearch = document.getElementById('start-search');
 const taskbarWins = document.getElementById('taskbar-windows');
 const toastContainer = document.getElementById('toast-container');
 const size      = { w: innerWidth, h: innerHeight };
@@ -306,20 +307,49 @@ APPS.forEach((app, i) => {
 layoutIcons();
 
 /* ---------- Menú Inicio ---------- */
+const startItems = [];
 APPS.forEach(app => {
   const item = document.createElement('div');
   item.className = 'start-item';
   item.innerHTML = `<img src="${app.icon}"><span>${app.name}</span>`;
   item.onclick = () => { startMenu.classList.remove('show'); spawnWindow(app); };
   startMenu.appendChild(item);
+  startItems.push({ el: item, app });
+});
+
+startSearch.addEventListener('input', () => {
+  const txt = startSearch.value.toLowerCase();
+  startItems.forEach(({ el, app }) => {
+    const name = app.name.toLowerCase();
+    el.style.display = name.includes(txt) ? 'flex' : 'none';
+  });
+});
+
+startSearch.addEventListener('keydown', e => {
+  if (e.key === 'Enter') {
+    const found = startItems.find(({ el }) => el.style.display !== 'none');
+    if (found) {
+      startMenu.classList.remove('show');
+      spawnWindow(found.app);
+      startSearch.value = '';
+      startItems.forEach(({ el }) => (el.style.display = 'flex'));
+    }
+  }
 });
 applyTheme(PREFS.theme);
 applyContrast(PREFS.contrast);
 applyLang(PREFS.lang);
-startButton.onclick = () => startMenu.classList.toggle('show');
+startButton.onclick = () => {
+  startMenu.classList.toggle('show');
+  if (startMenu.classList.contains('show')) {
+    startSearch.focus();
+  }
+};
 document.addEventListener('click', e => {
   if (!startMenu.contains(e.target) && e.target !== startButton) {
     startMenu.classList.remove('show');
+    startSearch.value = '';
+    startItems.forEach(({ el }) => (el.style.display = 'flex'));
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -28,3 +28,13 @@
   from{opacity:1;transform:translateY(0)}
   to{opacity:0;transform:translateY(20px)}
 }
+
+#start-search{
+  margin:0 8px 6px;
+  padding:4px 8px;
+  border:1px solid #ccc;
+  border-radius:4px;
+  background:var(--window);
+  color:var(--text);
+  width:calc(100% - 16px);
+}


### PR DESCRIPTION
## Summary
- add search input inside start menu
- filter start menu items while typing
- open the first match with Enter
- focus the search box when opening the menu
- style the search bar

## Testing
- `node --version`
- `node server.js` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_686c3549b4e083319e7e09e9ee8393fd