### PR TITLE
Add hand gesture cursor and clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,15 @@
     .task-icon{width:30px;height:30px;margin-left:6px;cursor:pointer}
     .task-icon img{width:100%;height:100%;border-radius:4px}
 
+    /* ---------- Cursor de mano ---------- */
+    #hand-cursor{
+      position:absolute;width:20px;height:20px;border:2px solid red;
+      border-radius:50%;pointer-events:none;z-index:4;
+      margin:-10px 0 0 -10px;display:none;
+    }
+    body.camera-active #hand-cursor{display:block}
+    body.camera-active{cursor:none}
+
     @keyframes fadeIn{from{transform:scale(.95);opacity:0}to{transform:scale(1);opacity:1}}
     @keyframes introUp{from{opacity:0;transform:translateY(40px)}to{opacity:1;transform:translateY(0)}}
     .intro{animation:introUp .4s forwards}
@@ -142,6 +151,7 @@
 <body>
   <div id="container"></div>
   <video id="camera"></video>
+  <div id="hand-cursor"></div>
 
   <!-- ---------- Ventana de inicio ---------- -->
   <div id="overlay">

--- a/src/hands.js
+++ b/src/hands.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-export function setupHands({ container, size, camera, sceneCSS, video }) {
+export function setupHands({ container, size, camera, sceneCSS, video, cursor }) {
   const ctx2 = (() => {
     const c = document.createElement('canvas');
     c.width = size.w; c.height = size.h;
@@ -20,31 +20,70 @@ export function setupHands({ container, size, camera, sceneCSS, video }) {
 
   let grabbing = false;
   let target   = null;
-  const finger = [4, 8];
+  const finger = [4, 8];             // pulgar e índice
+  const rightPair = [4, 12];         // pulgar y dedo medio
+  let leftPinch = false;
+  let rightPinch = false;
+  let pinchStart = 0;
+  let lastX = 0, lastY = 0;
+
+  function distPx(a, b) {
+    return Math.hypot((a.x - b.x) * size.w, (a.y - b.y) * size.h);
+  }
+
+  function dispatch(type, x, y, button) {
+    const el = document.elementFromPoint(x, y);
+    if (!el) return;
+    const ev = new PointerEvent(type, {
+      bubbles: true,
+      clientX: x,
+      clientY: y,
+      pointerId: 1,
+      pointerType: 'touch',
+      button,
+      buttons: button === 0 ? 1 : button === 2 ? 2 : 0
+    });
+    el.dispatchEvent(ev);
+  }
 
   hands.onResults(({ multiHandLandmarks: [lm] }) => {
     ctx2.clearRect(0, 0, size.w, size.h);
     if (!lm) {
+      if (cursor) cursor.style.display = 'none';
+      if (leftPinch) dispatch('pointerup', lastX, lastY, 0);
+      if (rightPinch) dispatch('pointerup', lastX, lastY, 2);
+      leftPinch = rightPinch = false;
       grabbing = false;
       target = null;
       return;
     }
+    if (cursor) cursor.style.display = 'block';
 
     drawConnectors(ctx2, lm, HAND_CONNECTIONS, { color: '#0f0', lineWidth: 2 });
     drawLandmarks(ctx2, lm, { color: '#0f0', lineWidth: 1 });
 
     const [p1, p2] = finger.map(i => lm[i]);
     const mid  = { x: (p1.x + p2.x) / 2 * size.w, y: (p1.y + p2.y) / 2 * size.h };
-    const dist = Math.hypot((p2.x - p1.x) * size.w, (p2.y - p1.y) * size.h);
+    const dist = distPx(p1, p2);
+    lastX = lm[8].x * size.w;
+    lastY = lm[8].y * size.h;
+    if (cursor) { cursor.style.left = `${lastX}px`; cursor.style.top = `${lastY}px`; }
+    dispatch('pointermove', lastX, lastY, leftPinch ? 0 : rightPinch ? 2 : 0);
+
+    const distR = distPx(...rightPair.map(i => lm[i]));
+    const now = performance.now();
 
     ctx2.beginPath();
     ctx2.arc(mid.x, mid.y, 10, 0, 2 * Math.PI);
     ctx2.fillStyle = 'rgba(255,0,0,.6)';
     ctx2.fill();
 
+    // Pinch izquierdo (click/arrastre)
     if (dist < 40) {
-      if (!grabbing) {
-        grabbing = true;
+      if (!leftPinch && !rightPinch) {
+        leftPinch = true;
+        pinchStart = now;
+        dispatch('pointerdown', lastX, lastY, 0);
         const ndc = new THREE.Vector3(
           (mid.x / size.w) * 2 - 1,
           -(mid.y / size.h) * 2 + 1,
@@ -56,18 +95,36 @@ export function setupHands({ container, size, camera, sceneCSS, video }) {
         );
         const hits = ray.intersectObjects(sceneCSS.children);
         target = hits[0]?.object ?? null;
+        grabbing = !!target;
       }
-      if (target) {
-        const ndc2 = new THREE.Vector3(
-          (mid.x / size.w) * 2 - 1,
-          -(mid.y / size.h) * 2 + 1,
-          target.position.z / (2000 / camera.far)
-        ).unproject(camera);
-        target.position.copy(ndc2);
-      }
-    } else {
+    } else if (leftPinch) {
+      leftPinch = false;
+      dispatch('pointerup', lastX, lastY, 0);
+      if (now - pinchStart < 300) dispatch('click', lastX, lastY, 0);
       grabbing = false;
       target   = null;
+    }
+
+    if (leftPinch && target) {
+      const ndc2 = new THREE.Vector3(
+        (mid.x / size.w) * 2 - 1,
+        -(mid.y / size.h) * 2 + 1,
+        target.position.z / (2000 / camera.far)
+      ).unproject(camera);
+      target.position.copy(ndc2);
+    }
+
+    // Pinch derecho (clic secundario)
+    if (distR < 40) {
+      if (!rightPinch && !leftPinch) {
+        rightPinch = true;
+        pinchStart = now;
+        dispatch('pointerdown', lastX, lastY, 2);
+      }
+    } else if (rightPinch) {
+      rightPinch = false;
+      dispatch('pointerup', lastX, lastY, 2);
+      if (now - pinchStart < 300) dispatch('contextmenu', lastX, lastY, 2);
     }
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ const startMenu   = document.getElementById('start-menu');
 const startSearch = document.getElementById('start-search');
 const taskbarWins = document.getElementById('taskbar-windows');
 const toastContainer = document.getElementById('toast-container');
+const handCursor = document.getElementById('hand-cursor');
 const size      = { w: innerWidth, h: innerHeight };
 
 /* ---------- Preferencias ---------- */
@@ -188,7 +189,7 @@ rendererCSS.domElement.style.zIndex = '10';
 rendererCSS.domElement.className    = 'css3d';
 
 initWindowSystem(sceneCSS, taskbarWins);
-setupHands({ container, size, camera, sceneCSS, video });
+setupHands({ container, size, camera, sceneCSS, video, cursor: handCursor });
 
 /* ---------- Fondo degradado ---------- */
 (() => {
@@ -395,6 +396,7 @@ document.addEventListener('click', e => {
 function startWithoutCamera(msg) {
   msgEl.textContent = msg;
   overlay.classList.remove('hidden');
+  document.body.classList.remove('camera-active');
   setTimeout(() => { overlay.classList.add('hidden'); runIntro(); }, 2000);
 }
 
@@ -414,6 +416,7 @@ function startCamera(deviceId) {
       video.style.opacity = '0';
       video.style.zIndex  = '-1';
       overlay.classList.add('hidden');
+      document.body.classList.add('camera-active');
       runIntro();
     })
     .catch(() => {


### PR DESCRIPTION
## Summary
- implement custom cursor that follows the tracked hand
- convert pinch gestures into pointer events for dragging, clicking and context menus
- hide the regular cursor while the camera is active

## Testing
- `node --version`
- `node server.js` *(launched then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686c4179b908833192afc5c001572f3a