### PR TITLE
Implement hand cursor and gestures

### DIFF
--- a/src/hands.js
+++ b/src/hands.js
@@ -1,6 +1,23 @@
 import * as THREE from 'three';
 
 export function setupHands({ container, size, camera, sceneCSS, video }) {
+  const cursor = document.createElement('div');
+  cursor.id = 'hand-cursor';
+  container.appendChild(cursor);
+  const cursorPos = { x: 0, y: 0 };
+  let leftDown = false;
+  let rightDown = false;
+  function sendMouse(type, button) {
+    const el = document.elementFromPoint(cursorPos.x, cursorPos.y);
+    if (!el) return;
+    const evt = new MouseEvent(type, {
+      bubbles: true,
+      clientX: cursorPos.x,
+      clientY: cursorPos.y,
+      button
+    });
+    el.dispatchEvent(evt);
+  }
   const ctx2 = (() => {
     const c = document.createElement('canvas');
     c.width = size.w; c.height = size.h;
@@ -25,17 +42,37 @@ export function setupHands({ container, size, camera, sceneCSS, video }) {
   hands.onResults(({ multiHandLandmarks: [lm] }) => {
     ctx2.clearRect(0, 0, size.w, size.h);
     if (!lm) {
+      cursor.style.display = 'none';
+      cursor.classList.remove('active');
+      if (leftDown) {
+        sendMouse('mouseup', 0);
+        leftDown = false;
+      }
+      if (rightDown) {
+        sendMouse('mouseup', 2);
+        rightDown = false;
+      }
       grabbing = false;
       target = null;
       return;
     }
+    cursor.style.display = 'block';
 
     drawConnectors(ctx2, lm, HAND_CONNECTIONS, { color: '#0f0', lineWidth: 2 });
     drawLandmarks(ctx2, lm, { color: '#0f0', lineWidth: 1 });
 
+    const idx = lm[8];
+    cursorPos.x = idx.x * size.w;
+    cursorPos.y = idx.y * size.h;
+    cursor.style.transform = `translate(${cursorPos.x}px,${cursorPos.y}px)`;
+
+    sendMouse('mousemove', 0);
+
     const [p1, p2] = finger.map(i => lm[i]);
     const mid  = { x: (p1.x + p2.x) / 2 * size.w, y: (p1.y + p2.y) / 2 * size.h };
     const dist = Math.hypot((p2.x - p1.x) * size.w, (p2.y - p1.y) * size.h);
+
+    const rightDist = Math.hypot((lm[12].x - lm[4].x) * size.w, (lm[12].y - lm[4].y) * size.h);
 
     ctx2.beginPath();
     ctx2.arc(mid.x, mid.y, 10, 0, 2 * Math.PI);
@@ -43,6 +80,11 @@ export function setupHands({ container, size, camera, sceneCSS, video }) {
     ctx2.fill();
 
     if (dist < 40) {
+      if (!leftDown) {
+        sendMouse('mousedown', 0);
+        leftDown = true;
+      }
+      cursor.classList.add('active');
       if (!grabbing) {
         grabbing = true;
         const ndc = new THREE.Vector3(
@@ -66,8 +108,28 @@ export function setupHands({ container, size, camera, sceneCSS, video }) {
         target.position.copy(ndc2);
       }
     } else {
+      if (leftDown) {
+        sendMouse('mouseup', 0);
+        sendMouse('click', 0);
+      }
+      leftDown = false;
+      cursor.classList.toggle('active', rightDown);
       grabbing = false;
       target   = null;
+    }
+
+    if (rightDist < 40) {
+      if (!rightDown) {
+        sendMouse('mousedown', 2);
+        rightDown = true;
+      }
+      cursor.classList.add('active');
+    } else if (rightDown) {
+      sendMouse('mouseup', 2);
+      const el = document.elementFromPoint(cursorPos.x, cursorPos.y);
+      if (el) el.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: cursorPos.x, clientY: cursorPos.y, button: 2 }));
+      rightDown = false;
+      cursor.classList.toggle('active', leftDown);
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -38,3 +38,18 @@
   color:var(--text);
   width:calc(100% - 16px);
 }
+
+#hand-cursor{
+  position:absolute;
+  width:20px;
+  height:20px;
+  border:2px solid #fff;
+  border-radius:50%;
+  pointer-events:none;
+  z-index:3;
+  transform:translate(-50%, -50%);
+  transition:background .1s;
+}
+#hand-cursor.active{
+  background:rgba(255,255,255,.5);
+}


### PR DESCRIPTION
## Summary
- add a visible hand cursor that follows the detected hand
- dispatch mouse events from hand gestures
- add pinch based right-click support
- style the new cursor

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686c474a8d68833187541cea3a961e18