### PR TITLE
Fix FaceMesh CDN path

### DIFF
--- a/src/gaze.js
+++ b/src/gaze.js
@@ -1,6 +1,7 @@
 export function setupGaze({ video, onUpdate }) {
   const face = new FaceMesh({
-    locateFile: f => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4/${f}`
+    // Match FaceMesh script version
+    locateFile: f => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/${f}`
   });
   face.setOptions({
     maxNumFaces: 1,


### PR DESCRIPTION
## Summary
- point `locateFile` in `src/gaze.js` at the FaceMesh version on the CDN
- add comment noting that the path matches the loaded FaceMesh version

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c7bce6a6c8331b187640f2018cfd8