### PR TITLE
Centralize prefs in state store

### DIFF
--- a/src/apps.js
+++ b/src/apps.js
@@ -1,5 +1,6 @@
 import { runPluginApp } from './pluginApi.js';
 import fs from './fs.js';
+import store, { updatePrefs } from './state.js';
 
 export function createApp(id, cont, win) {
   if (runPluginApp(id, cont, win)) return;
@@ -160,23 +161,23 @@ export function createApp(id, cont, win) {
 
       const themeSel = document.createElement('select');
       themeSel.innerHTML = '<option value="light">Claro</option><option value="dark">Oscuro</option>';
-      themeSel.value = window.PREFS.theme;
-      themeSel.onchange = () => { window.PREFS.theme = themeSel.value; window.applyTheme(themeSel.value); window.savePrefs(); };
+      themeSel.value = store.prefs.theme;
+      themeSel.onchange = () => updatePrefs({ theme: themeSel.value });
 
       const wallSel = document.createElement('select');
       wallSel.innerHTML = '<option value="default">Azul</option><option value="sunset">Atardecer</option><option value="forest">Bosque</option>';
-      wallSel.value = window.PREFS.wallpaper;
-      wallSel.onchange = () => { window.PREFS.wallpaper = wallSel.value; window.applyWallpaper(wallSel.value); window.savePrefs(); };
+      wallSel.value = store.prefs.wallpaper;
+      wallSel.onchange = () => updatePrefs({ wallpaper: wallSel.value });
 
       const langSel = document.createElement('select');
       langSel.innerHTML = '<option value="es">Español</option><option value="en">English</option>';
-      langSel.value = window.PREFS.lang;
-      langSel.onchange = () => { window.PREFS.lang = langSel.value; window.applyLang(langSel.value); window.savePrefs(); };
+      langSel.value = store.prefs.lang;
+      langSel.onchange = () => updatePrefs({ lang: langSel.value });
 
       const contrastSel = document.createElement('select');
       contrastSel.innerHTML = '<option value="normal">Normal</option><option value="high">Alto</option>';
-      contrastSel.value = window.PREFS.contrast;
-      contrastSel.onchange = () => { window.PREFS.contrast = contrastSel.value; window.applyContrast(contrastSel.value); window.savePrefs(); };
+      contrastSel.value = store.prefs.contrast;
+      contrastSel.onchange = () => updatePrefs({ contrast: contrastSel.value });
 
       cont.append('Tema:', themeSel, 'Fondo:', wallSel, 'Idioma:', langSel, 'Contraste:', contrastSel);
       break;

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { initWindowSystem, spawnWindow } from './win.js';
 import { setupHands } from './hands.js';
 import { setupGaze } from './gaze.js';
 import { APPS } from './pluginApi.js';
+import store, { subscribe } from './state.js';
 import * as CANNON from 'cannon-es';
 
 /* ---------- Constantes ---------- */
@@ -25,14 +26,7 @@ const gaze      = { x: 0, y: 0 };
 const tilt      = { beta: 0, gamma: 0 };
 
 /* ---------- Preferencias ---------- */
-const PREFS = JSON.parse(localStorage.getItem('prefs') || '{}');
-Object.assign(PREFS, {
-  theme: PREFS.theme || 'light',
-  wallpaper: PREFS.wallpaper || 'default',
-  lang: PREFS.lang || 'es',
-  contrast: PREFS.contrast || 'normal'
-});
-function savePrefs() { localStorage.setItem('prefs', JSON.stringify(PREFS)); }
+const PREFS = store.prefs;
 
 const THEMES = {
   light:  { '--accent': '#0078d4', '--text': '#333', '--window': '#fff' },
@@ -136,12 +130,13 @@ function applyLang(l) {
   });
 }
 
-window.PREFS = PREFS;
-window.savePrefs = savePrefs;
-window.applyTheme = applyTheme;
-window.applyWallpaper = applyWallpaper;
-window.applyLang = applyLang;
-window.applyContrast = applyContrast;
+subscribe(state => {
+  applyTheme(state.prefs.theme);
+  applyWallpaper(state.prefs.wallpaper);
+  applyLang(state.prefs.lang);
+  applyContrast(state.prefs.contrast);
+});
+
 
 function showToast(msg) {
   const el = document.createElement('div');
@@ -253,7 +248,7 @@ if (window.DeviceOrientationEvent) {
   );
   quad.position.z = -500;      // dentro del frustum
   sceneGL.add(quad);
-  applyWallpaper(PREFS.wallpaper);
+  applyWallpaper(store.prefs.wallpaper);
 })();
 
 /* ---------- Partículas ---------- */
@@ -460,9 +455,9 @@ startSearch.addEventListener('keydown', e => {
     }
   }
 });
-applyTheme(PREFS.theme);
-applyContrast(PREFS.contrast);
-applyLang(PREFS.lang);
+applyTheme(store.prefs.theme);
+applyContrast(store.prefs.contrast);
+applyLang(store.prefs.lang);
 startButton.onclick = () => {
   startMenu.classList.toggle('show');
   if (startMenu.classList.contains('show')) {

--- a/src/pluginApi.js
+++ b/src/pluginApi.js
@@ -1,17 +1,12 @@
-export const APPS = [
-  { id: 'term',  name: 'Terminal',     icon: 'https://img.icons8.com/fluency/96/console.png' },
-  { id: 'edit',  name: 'Editor',       icon: 'https://img.icons8.com/fluency/96/notepad.png' },
-  { id: 'web',   name: 'Web',          icon: 'https://img.icons8.com/fluency/96/internet.png' },
-  { id: 'clock', name: 'Reloj',        icon: 'https://img.icons8.com/fluency/96/alarm.png' },
-  { id: 'calc',  name: 'Calculadora',  icon: 'https://img.icons8.com/fluency/96/calculator.png' },
-  { id: 'settings', name: 'Ajustes',   icon: 'https://img.icons8.com/fluency/96/settings.png' }
-];
+import store, { addApp } from './state.js';
+
+export const APPS = store.apps;
 
 const plugins = {};
 
 export function registerApp(info, handler) {
   if (!info || !info.id || typeof handler !== 'function') return;
-  APPS.push({ id: info.id, name: info.name || info.id, icon: info.icon || '' });
+  addApp({ id: info.id, name: info.name || info.id, icon: info.icon || '' });
   plugins[info.id] = handler;
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,47 @@
+const PREF_KEY = 'prefs';
+let stored = {};
+try {
+  stored = JSON.parse(localStorage.getItem(PREF_KEY)) || {};
+} catch {
+  stored = {};
+}
+
+const store = {
+  prefs: {
+    theme: stored.theme || 'light',
+    wallpaper: stored.wallpaper || 'default',
+    lang: stored.lang || 'es',
+    contrast: stored.contrast || 'normal'
+  },
+  apps: [
+    { id: 'term',  name: 'Terminal',     icon: 'https://img.icons8.com/fluency/96/console.png' },
+    { id: 'edit',  name: 'Editor',       icon: 'https://img.icons8.com/fluency/96/notepad.png' },
+    { id: 'web',   name: 'Web',          icon: 'https://img.icons8.com/fluency/96/internet.png' },
+    { id: 'clock', name: 'Reloj',        icon: 'https://img.icons8.com/fluency/96/alarm.png' },
+    { id: 'calc',  name: 'Calculadora',  icon: 'https://img.icons8.com/fluency/96/calculator.png' },
+    { id: 'settings', name: 'Ajustes',   icon: 'https://img.icons8.com/fluency/96/settings.png' }
+  ]
+};
+
+const listeners = new Set();
+function notify() {
+  listeners.forEach(fn => fn(store));
+}
+
+export function updatePrefs(newPrefs) {
+  Object.assign(store.prefs, newPrefs);
+  localStorage.setItem(PREF_KEY, JSON.stringify(store.prefs));
+  notify();
+}
+
+export function addApp(app) {
+  store.apps.push(app);
+  notify();
+}
+
+export function subscribe(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export default store;


### PR DESCRIPTION
## Summary
- create `state.js` with a single store for preferences and apps
- use the new store in the plugin API
- switch settings app to `updatePrefs`
- import the store in `main.js` and react to preference changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8e0d98b8833196069f022e2ac225