### PR TITLE
Defer MediaPipe loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,10 +56,7 @@
   }
   </script>
 
-  <!-- MediaPipe Hands v0.10.x -->
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils@0.3.1675466124/drawing_utils.min.js"></script>
+  <!-- MediaPipe libs are dynamically loaded -->
 
   <!-- =======================  APP  ======================= -->
   <script type="module" src="src/splash.js"></script>

--- a/src/gaze.js
+++ b/src/gaze.js
@@ -1,24 +1,33 @@
 export function setupGaze({ video, onUpdate }) {
-  const face = new FaceMesh({
-    // Match FaceMesh script version
-    locateFile: f => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/${f}`
-  });
-  face.setOptions({
-    maxNumFaces: 1,
-    refineLandmarks: true,
-    minDetectionConfidence: 0.5,
-    minTrackingConfidence: 0.5
-  });
-  face.onResults(({ multiFaceLandmarks: [lm] }) => {
-    if (!lm) { onUpdate(0, 0); return; }
-    const nose = lm[1];
-    const x = (nose.x - 0.5) * 2;
-    const y = (0.5 - nose.y) * 2;
-    onUpdate(x, y);
-  });
-  video.addEventListener('playing', function loop() {
-    face.send({ image: video });
-    requestAnimationFrame(loop);
+  let face;
+  video.addEventListener('playing', async function init() {
+    video.removeEventListener('playing', init);
+    try {
+      const mod = await import('https://cdn.skypack.dev/@mediapipe/face_mesh');
+      const { FaceMesh } = mod;
+      face = new FaceMesh({
+        locateFile: f => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/${f}`
+      });
+      face.setOptions({
+        maxNumFaces: 1,
+        refineLandmarks: true,
+        minDetectionConfidence: 0.5,
+        minTrackingConfidence: 0.5
+      });
+      face.onResults(({ multiFaceLandmarks: [lm] }) => {
+        if (!lm) { onUpdate(0, 0); return; }
+        const nose = lm[1];
+        const x = (nose.x - 0.5) * 2;
+        const y = (0.5 - nose.y) * 2;
+        onUpdate(x, y);
+      });
+      (function loop() {
+        face.send({ image: video });
+        requestAnimationFrame(loop);
+      })();
+    } catch (e) {
+      window.showToast && window.showToast('Error al cargar MediaPipe FaceMesh');
+    }
   });
   return face;
 }

--- a/src/hands.js
+++ b/src/hands.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+let drawConnectors, drawLandmarks, HAND_CONNECTIONS;
+
 export class HandTracker {
   constructor({ container, size, camera, sceneCSS }) {
     this.size = size;
@@ -22,14 +24,26 @@ export class HandTracker {
     container.appendChild(canvas);
     this.ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-    this.worker = new Worker('../workers/handsWorker.js');
-    this.worker.onmessage = e => this.onResults(e.data);
-    this.worker.postMessage({ type: 'init' });
+    this.worker = null;
   }
 
   start(video) {
     this.video = video;
-    video.addEventListener('playing', () => this.loop());
+    video.addEventListener('playing', async () => {
+      try {
+        const mod = await import('https://cdn.skypack.dev/@mediapipe/drawing_utils');
+        drawConnectors = mod.drawConnectors;
+        drawLandmarks = mod.drawLandmarks;
+        HAND_CONNECTIONS = mod.HAND_CONNECTIONS;
+      } catch (e) {
+        window.showToast && window.showToast('Error al cargar MediaPipe Hands');
+        return;
+      }
+      this.worker = new Worker('../workers/handsWorker.js');
+      this.worker.onmessage = e => this.onResults(e.data);
+      this.worker.postMessage({ type: 'init' });
+      this.loop();
+    }, { once: true });
   }
 
   async loop() {


### PR DESCRIPTION
## Summary
- remove global MediaPipe `<script>` tags
- load MediaPipe drawing utils and face mesh at runtime
- show an error toast if dynamic import fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c913cb1fc8331b1353e5b084d909f