### PR TITLE
Fix MediaPipe loading path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ calculator.
 ## Requirements
 - Modern browser with WebGL and camera access
 - Node.js (optional, for local server)
-- Internet connection (MediaPipe runtime files are fetched from CDN)
+- Internet connection (first time MediaPipe assets may be fetched from CDN)
 
 ## Running the demo
 You can open `index.html` directly in your browser. For convenience a small

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
         content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
   <title>OS 3D — Interacción Mano</title>
-  <!-- <base href="/OS/">  Descomenta si tu página está en /OS/ dentro de GitHub Pages -->
+  <base href="/OS/">  <!-- Ruta base para GitHub Pages -->
+  <script src="./vendor/mediapipe/face_mesh.min.js"></script>
+  <script src="./vendor/mediapipe/hands.min.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">

--- a/src/gaze.js
+++ b/src/gaze.js
@@ -3,8 +3,8 @@ export function setupGaze({ video, onUpdate }) {
   video.addEventListener('playing', async function init() {
     video.removeEventListener('playing', init);
     try {
-      const mod = await import('../vendor/mediapipe/face_mesh.min.js');
-      const { FaceMesh } = mod;
+      const { FaceMesh } = globalThis;
+      if (!FaceMesh) throw new Error('FaceMesh not loaded');
       face = new FaceMesh({
         locateFile: f => `../vendor/mediapipe/${f}`
       });


### PR DESCRIPTION
## Summary
- add `<base>` tag and local MediaPipe scripts to `index.html`
- access global `FaceMesh` instead of dynamic import
- clarify README about MediaPipe asset download

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_686d94155bfc8331b429d41348674514