### PR TITLE
Fix local asset paths for mediapipe and hand model

### DIFF
--- a/src/gaze.js
+++ b/src/gaze.js
@@ -6,7 +6,7 @@ export function setupGaze({ video, onUpdate }) {
       const { FaceMesh } = globalThis;
       if (!FaceMesh) throw new Error('FaceMesh not loaded');
       face = new FaceMesh({
-        locateFile: f => `../vendor/mediapipe/${f}`
+        locateFile: f => `vendor/mediapipe/${f}`
       });
       face.setOptions({
         maxNumFaces: 1,

--- a/src/hands.js
+++ b/src/hands.js
@@ -43,7 +43,7 @@ export class HandTracker {
         return;
       }
       const loader = new GLTFLoader();
-      loader.load('../models/hand.glb', glb => {
+      loader.load('models/hand.glb', glb => {
         this.handModel = glb.scene;
         this.handModel.scale.setScalar(200);
         this.handModel.visible = false;


### PR DESCRIPTION
## Summary
- correct local path for Mediapipe assets so FaceMesh loads correctly
- fix GLTF loader path for hand model

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_686dac89e8708331bd07e22ebd6a35bf